### PR TITLE
se elimino la categoria otros de los formularios de producto

### DIFF
--- a/db.json
+++ b/db.json
@@ -35,15 +35,6 @@
       "categoria": "Pastas",
       "imagen": "https://images.pexels.com/photos/4079520/pexels-photo-4079520.jpeg",
       "id": 4
-    },
-    {
-      "nombre": "Papas Gratinadas",
-      "estado": "Activo",
-      "precio": 1850,
-      "detalle": "papas rusticas con queso gratinado",
-      "categoria": "Otros",
-      "imagen": "https://cdn.doers.video/embed/4d4ab84e712462c163a143882640fb1d496601526425813/5983b2248ba4d.jpg",
-      "id": 5
     }
   ],
   "usuarios": [

--- a/src/components/views/productos/CrearProducto.jsx
+++ b/src/components/views/productos/CrearProducto.jsx
@@ -124,7 +124,6 @@ const CrearProducto = () => {
                         <option value="Bebidas sin alcohol">Bebidas sin alcohol</option>
                         <option value="Pastas">Pastas</option>
                         <option value="Pizzas">Pizzas</option>
-                        <option value="Otros">Otros</option>
                     </Form.Select>
                     <Form.Text className="text-danger">{errors.categoria?.message}</Form.Text>
                 </Form.Group>

--- a/src/components/views/productos/EditarProducto.jsx
+++ b/src/components/views/productos/EditarProducto.jsx
@@ -155,7 +155,6 @@ const EditarProducto = () => {
             <option value="Bebidas sin alcohol">Bebidas sin alcohol</option>
             <option value="Pastas">Pastas</option>
             <option value="Pizzas">Pizzas</option>
-            <option value="Otros">Otros</option>
           </Form.Select>
           <Form.Text className="text-danger">
             {errors.categoria?.message}


### PR DESCRIPTION
se elimino la categoria otros de los formularios de producto, ya sea crear o editar porque no estaban definidas para usarse